### PR TITLE
finished unassign all open tickets checkbox

### DIFF
--- a/app.css
+++ b/app.css
@@ -197,3 +197,14 @@ td.size {
 #ticket_dash p .label {
   font-size: 100%;
 }
+
+button.btn-canel {
+  clear: both;
+}
+
+span.option {
+  display: block;
+  left: 0;
+  margin-bottom: 10px;
+  margin-right: 65%;
+}

--- a/templates/layout.hdbs
+++ b/templates/layout.hdbs
@@ -18,6 +18,7 @@
      <p>This action will reassign <span class='users-name'></span>'s open tickets and change their status to away. Please confirm.</p>
    </div>
    <div class="modal-footer">
+     <span class="option"></span>
      <button class="btn btn-cancel modalCancel" data-dismiss="modal" aria-hidden="true">Cancel</button>
      <button id="confirm" class="btn btn-primary btn-confirm modalAccept" aria-hidden="true">Yes, Mark this agent as away</button>
    </div>


### PR DESCRIPTION
@Nebopolis @didntlisten @msirianni @jeremiahcurrier this adds a checkbox to the "mark as away" screen that unassigns all open tickets of the user (unless one of the tickets is assigned to the agent where he is the only member of the group, then cannot unassign of course).
