### PR TITLE
Fixed #179

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,6 +76,7 @@
             var failMessage = this.I18n.t('saveFailMessage');
             return '<p style="margin-top: 16px; margin-bottom: 10px; text-align: center; font-weight: bold; font-size: 20px;">' + failMessage + '</p>';
         },
+
         saveWarningMessage: function(name) {  //TODO: rework current strings to use placeholders instead of concatenation
             var warnStatus  = this.I18n.t('saveWarningMessage.status'),
                 warnMessage = this.I18n.t('saveWarningMessage.message');

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -238,13 +238,16 @@ module.exports = {
             return true;
         }  else if(assignee.id() == currentUser ||  //let a user modify their own tickets 
             !util.settings.preventAssignOOO) {     //allow tickets to be updaded if preventAssignOOO is false
-            app.ajax('getSingleAgent', assignee.id()).done(function(agent) {
-                agent = agent.user; //unpack agent
-                if(agent.user_fields[options.userFieldKey]) {
+            return app.promise(function(done, fail) { //added promise to ensure that notification happens before ticket is closed.
+                app.ajax('getSingleAgent', assignee.id()).done(function(agent) {
+                    agent = agent.user; //unpack agent
                     app.trigger('update_warning', {agent: agent});
-                }
-            }).fail(function(error) {saveFail(error, 'getSingleAgent', false);});
-            return true;
+                    done();
+                }).fail(function(error) {
+                    saveFail(error, 'getSingleAgent', false);
+                    done();
+                });
+            });
         } else {
             return app.promise(function(done, fail) { 
                 app.ajax('getSingleAgent', assignee.id()).done(function(agent) { 


### PR DESCRIPTION
Turns out you need to use a promise to ensure that the notification for status is sent _before_ the ticket has been closed (if stay on ticket is not selected)
added a promise that should still succeed even if the network request fails, if network request fails the notification will not be sent.

Risks:
Low Risk (3/10), High Impact (10/10):
May break save hook if :assignee.id() == currentUser || !preventAssignOOO
worst case: saving may fail for all tickets where user is assignee, or all tickets if !preventAssignOOO. 
most likely negative impact: increase in latency for saving tickets
