### PR TITLE
Custom role id permissions

### DIFF
--- a/lib/ui.js
+++ b/lib/ui.js
@@ -2,7 +2,7 @@ var requests = {
 
     getAllAgents: function(page) {
         return {
-            url: helpers.fmt('/api/v2/users.json?role[]=agent&role[]=admin&page=%@', page)
+            url: helpers.fmt('/api/v2/users.json?role[]=agent&role[]=admin&page=%@?include=abilities', page)
         };
     },
 
@@ -33,13 +33,13 @@ var util = {
             sortOrder = 'asc',
             users = util.sortUsers(util.users, sortHeader, sortOrder),
             currentUser = app.currentUser(),
-            hasPermission = (currentUser.role() == 'admin') ? true
-                                                            : false;
+            hasPermission = (currentUser.role() == this.setting('customRole')) ? true : false || 
+	      (currentUser.role() == 'admin') ? true : false;
         users.forEach(function(user) {
             if(app.updating[user.id]) {
                 user.updating = app.updating[user.id].tagging;
                 user.percentage = app.updating[user.id].percentage;
-                if(user.updating) {
+		if(user.updating) {
                     console.log(app.updating[user.id]);
                     var status = user.user_fields[util.settings.userFieldKey];
                     status = app.updating[user.id].invert ? status : !status;

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -27,11 +27,11 @@ var util = {
     renderFilter: function(app) {
         app = app || util.appFramework;
 
-	if (app.setting('customRole') != null) {
+	/*if (app.setting('customRole') != null) {
 	console.log(app.setting('customRole'));
 	console.log(app.setting('customRole').toString());
 	console.log(app.currentUser().role());
-	}
+	}*/
         var searchBox = app.$('#filter_search'),
             currentSort = app.$('#agent_list thead .current'),
             sortHeader = 'name_head',

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -2,7 +2,7 @@ var requests = {
 
     getAllAgents: function(page) {
         return {
-            url: helpers.fmt('/api/v2/users.json?role[]=agent&role[]=admin&page=%@?include=abilities', page)
+            url: helpers.fmt('/api/v2/users.json?role[]=agent&role[]=admin&include=abilities&page=%@', page)
         };
     },
 
@@ -27,13 +27,18 @@ var util = {
     renderFilter: function(app) {
         app = app || util.appFramework;
 
+	if (app.setting('customRole') != null) {
+	console.log(app.setting('customRole'));
+	console.log(app.setting('customRole').toString());
+	console.log(app.currentUser().role());
+	}
         var searchBox = app.$('#filter_search'),
             currentSort = app.$('#agent_list thead .current'),
             sortHeader = 'name_head',
             sortOrder = 'asc',
             users = util.sortUsers(util.users, sortHeader, sortOrder),
             currentUser = app.currentUser(),
-            hasPermission = (currentUser.role() == this.setting('customRole')) ? true : false || 
+            hasPermission = (currentUser.role() == app.setting('customRole')) ? true : false || 
 	      (currentUser.role() == 'admin') ? true : false;
         users.forEach(function(user) {
             if(app.updating[user.id]) {

--- a/manifest.json
+++ b/manifest.json
@@ -50,6 +50,10 @@
       "name": "navbarVisibility",
       "type": "checkbox",
       "default": true
+    },
+    {
+      "name": "customRole",
+      "type": "number"
     }
   ]
 }

--- a/templates/navbar.hdbs
+++ b/templates/navbar.hdbs
@@ -21,8 +21,8 @@
             <td class="size"><a style="color: #555; font-size: 13px; letter-spacing: 0.25px;" href="#/users/{{id}}">{{email}}</a></td>
             <td class="size">
               <div class="toggleswitch progress progress-striped active" style="float:left;">
-                <input type="checkbox" name="toggleswitch" class="toggleswitch-checkbox" id="mytoggleswitch-{{id}}" {{#unless user_fields.agent_ooo}}checked{{/unless}} {{#unless ../permission}}disabled{{/unless}} data-assignee={{id}}>
-                <label class="toggleswitch-label {{#unless ../permission}}disabled{{/unless}}" for="mytoggleswitch-{{id}}">
+                <input type="checkbox" name="toggleswitch" class="toggleswitch-checkbox" id="mytoggleswitch-{{id}}" {{#unless user_fields.agent_ooo}}checked{{/unless}} {{#unless ../permission}}{{#unless can_edit}}disabled{{/unless}}{{/unless}} data-assignee={{id}}>
+                <label class="toggleswitch-label {{#unless ../permission}}{{#unless can_edit}}disabled{{/unless}}{{/unless}}" for="mytoggleswitch-{{id}}">
                     {{#if updating}}
                     <div class="toggleswitch-during"><div class="bar" style="width:{{percentage}}%">Updating</div></div>
                     {{else}}

--- a/translations/en.json
+++ b/translations/en.json
@@ -6,7 +6,8 @@
       "preventAssignOOO": { "label": "Prevent assignment?", "helpText": "Have the app block updates that assign a ticket to an unavailable agent." },
       "ticketSidebarVisibility": { "label": "Make app visible in ticket sidebar?" },
       "userSidebarVisibility": { "label": "Make app visible in user sidebar?" },
-      "navbarVisibility": { "label": "Make app visible in navbar to non-admins?"}
+      "navbarVisibility": { "label": "Make app visible in navbar to non-admins?"},
+      "customRole": { "label": "Custom Role id", "helpText": "Give custom role permissions" }
     }
   },
   "trigger": {


### PR DESCRIPTION
Adds a numeric field for login screen where an admin can specify a numeric role id they wish to have access to setting OOO status for all agents. (This role must have user write access).