### PR TITLE
Pipeline requests to the view previews, fix toggleswitch IDs

### DIFF
--- a/lib/get_all.js
+++ b/lib/get_all.js
@@ -25,7 +25,7 @@ var util = {
     },
     
 
-    getRows: function(member, request, done, fail, data, progressCallback) {
+    getRows: function(member, request, pages, done, fail, data, progressCallback) {
         data = data || [];
         if(request[2] === undefined) {  //assumes that the request has one paramater - TODO: generalize
             request.push(1);
@@ -35,11 +35,11 @@ var util = {
             if(progressCallback) {
                 progressCallback(newdata, data, request);
             }
-            if(newdata.next_page === null) { //check to see if there is another page to load
+            if(pages.length <= 0) { //check to see if there is another page to load
                 done(data);
             } else {
-                request[2] = util.stripNumber(newdata.next_page);
-                util.getRows(member, request, done, fail, data, progressCallback); //if there is another page, call getAll again - will eventually reach the end and call done()
+                request[2] = pages.pop();
+                util.getRows(member, request, pages, done, fail, data, progressCallback); //if there is another page, call getAll again - will eventually reach the end and call done()
             }
         }).fail(function(error) {
             util.appFramework.trigger('network_error', {request: request[0], requestType: 'getRows', member: member, data: data, error: error});
@@ -101,8 +101,41 @@ module.exports = {
     },
 
     getView: function(member, request, progressCallback) {
+        var pipeline = 5;
         return util.appFramework.promise(function(done, fail) {
-            util.getRows(member, request, done, fail, [], progressCallback);
+            util.appFramework.ajax.apply(util.appFramework, request).done(function(data) {
+                if(progressCallback) {
+                    progressCallback(data, data[member], request);
+                }
+                var pages = Math.ceil(data.count / 100);
+                var sectionLength = pages / pipeline;
+                if(pages < 2) {
+                    done(data[member]);
+                } else {
+                    var additional_pages = [];
+                    for (var i = 2; i <= pages; i++) {
+                        additional_pages.push(i);
+                    }
+                    var sections = util.splitArray(additional_pages, sectionLength);
+                    var requests = [];
+                    var final_data = data[member];
+                    var one_section = function(section) {
+                        return util.appFramework.promise(function(done, fail) {
+                            var local_request = request;
+                            local_request[2] = section.pop();
+                            util.getRows(member, request, section, done, fail, [], progressCallback);
+                        });
+                    };
+                    var concat_data = function(data) {final_data = final_data.concat(data);};
+
+                    sections.forEach(function(section) {
+                        requests.push(one_section(section).done(concat_data).fail(fail));
+                    });
+                    util.appFramework.when.apply(util.appFramework, requests).done(function() {
+                        done(final_data);
+                    }).fail(fail);
+                }
+            });
         });
     },
     

--- a/templates/ticket.hdbs
+++ b/templates/ticket.hdbs
@@ -5,8 +5,8 @@
     </div>
     <div class="col-half omega">
       <div class="toggleswitch progress progress-striped active">
-        <input type="checkbox" name="toggleswitch" class="toggleswitch-checkbox" id="mytoggleswitch-ticket" {{#unless assignee.user_fields.agent_ooo}}checked{{/unless}} {{#unless permission}}disabled{{/unless}} data-assignee={{assignee.id}}>
-        <label class="toggleswitch-label {{#unless permission}}disabled{{/unless}}" for="mytoggleswitch-ticket">
+        <input type="checkbox" name="toggleswitch" class="toggleswitch-checkbox" id="mytoggleswitch-ticket-{{assignee-id}}" {{#unless assignee.user_fields.agent_ooo}}checked{{/unless}} {{#unless permission}}disabled{{/unless}} data-assignee={{assignee.id}}>
+        <label class="toggleswitch-label {{#unless permission}}disabled{{/unless}}" for="mytoggleswitch-ticket-{{assignee-id}}">
             {{#if updating}}
             <div class="toggleswitch-during"><div class="bar" style="width:{{percentage}}%">Updating</div></div>
             {{else}}

--- a/templates/user.hdbs
+++ b/templates/user.hdbs
@@ -10,8 +10,8 @@
 </div>
 <div class="col-half omega">
       <div class="toggleswitch progress progress-striped active">
-        <input type="checkbox" name="toggleswitch" class="toggleswitch-checkbox" id="mytoggleswitch-user" {{#unless user.user_fields.agent_ooo}}checked{{/unless}} {{#unless permission}}disabled{{/unless}} data-assignee={{user.id}}>
-        <label class="toggleswitch-label {{#unless permission}}disabled{{/unless}}" for="mytoggleswitch-user">
+        <input type="checkbox" name="toggleswitch" class="toggleswitch-checkbox" id="mytoggleswitch-user-{{user.id}}" {{#unless user.user_fields.agent_ooo}}checked{{/unless}} {{#unless permission}}disabled{{/unless}} data-assignee={{user.id}}>
+        <label class="toggleswitch-label {{#unless permission}}disabled{{/unless}}" for="mytoggleswitch-user-{{user.id}}">
             {{#if updating}}
             <div class="toggleswitch-during"><div class="bar" style="width:{{percentage}}%">Updating</div></div>
             {{else}}


### PR DESCRIPTION
- toggleswitch IDs were overlapping which caused incorrect updates
- updating tickets was slow because we still needed to get the list in a sequential manner 