### PR TITLE
unassign open tickets option fixed

### DIFF
--- a/lib/popmodal.js
+++ b/lib/popmodal.js
@@ -13,7 +13,7 @@
 var util = {
     version: '.02',
     getOptions: function() {
-        return util.appFramework.$(".mymodal span.option :input").not('button');
+        return util.appFramework.$(".mymodal div.option :input").not('button');
     }
 };
 
@@ -44,7 +44,6 @@ module.exports = {
         util.appFramework.$('.modalAccept').on('click', function() {
             util.appFramework.$('.mymodal').modal('hide');
             var options = util.getOptions();
-            util.appFramework.$('span.option').html("");
             if(onAccept !== undefined) {
                 onAccept(options);
             }
@@ -52,8 +51,6 @@ module.exports = {
         util.appFramework.$('.modalCancel').on('click', function() {
             util.appFramework.$('.mymodal').modal('hide');
             var options = util.getOptions();
-            util.appFramework.$('span.option').html("");
-
             if(onCancel !== undefined) {
                 onCancel(options);
             }


### PR DESCRIPTION
The user option used if Confirm status change? is true and Force unassign tickets? false didn't work

![image](https://cloud.githubusercontent.com/assets/3614135/15812273/20dcf5e6-2bb3-11e6-8126-0712534202d9.png)
